### PR TITLE
integrate cardholder component into stall and venue selection display…

### DIFF
--- a/frontend/app/runner/venue/[venueId]/stall/selectstall/page.tsx
+++ b/frontend/app/runner/venue/[venueId]/stall/selectstall/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BackButton } from "@/components/ui/button"
+import { DisplayGrid } from "@/components/ui/displaygrid";
 import { useRouter, useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Stall } from "../../../../../../../types/stall";
@@ -55,36 +56,16 @@ export default function Home() {
         ) : error ? (
           <p className="text-red-500">Error: {error}</p>
         ) : (
-          <ul className="mt-4 space-y-3">
-            {stalls.length > 0 ? (
-              stalls.map((stall) => (
-                <li key={stall.stall_id}>
-                  <div 
-                  className="flex items-center gap-3 rounded-xl bg-white shadow-sm px-3 py-3 active:scale-[0.98] transition"
-                  onClick={() => router.push(`/runner/venue/${venueId}/stall/${stall.stall_id}/orders`)}>
-                    {/* Shop image */}
-                    <img
-                      src={stall.stall_image}
-                      alt={stall.name}
-                      className="w-16 h-16 rounded-md object-cover flex-shrink-0"
-                    />
-
-                    {/* Text content */}
-                    <div className="flex flex-col">
-                      <span className="font-semibold text-[15px] text-black leading-tight">
-                        {stall.name}
-                      </span>
-                      <span className="text-sm text-gray-500 leading-tight">
-                        {stall.description}
-                      </span>
-                    </div>
-                  </div>
-                </li>
-              ))
-            ) : (
-              <li>No stalls found</li>
-            )}
-          </ul>
+          <DisplayGrid
+            items={stalls.map((stall) => ({
+              id: stall.stall_id,
+              name: stall.name,
+              img: stall.stall_image,
+              isActive: stall.is_open,
+            }))}
+            variant="stall"
+            href={(id: string) => `/runner/venue/${venueId}/stall/${id}/orders`}
+          />
         )}
       </div>
     </main>

--- a/frontend/app/runner/venue/selectvenue/page.tsx
+++ b/frontend/app/runner/venue/selectvenue/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BackButton } from "@/components/ui/button"
+import { DisplayGrid } from "@/components/ui/displaygrid";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Venue } from "../../../../../types/venue";
@@ -55,39 +56,15 @@ export default function Home() {
         ) : error ? (
           <p className="text-red-500">Error: {error}</p>
         ) : (
-          <ul className="mt-4 space-y-3">
-            {venues.length > 0 ? (
-              venues.map((venue) => (
-                <li key={venue.venue_id}>
-                  <div
-                    className="flex items-center gap-3 rounded-xl bg-white shadow-sm px-3 py-3 active:scale-[0.98] transition"
-                    onClick={() =>
-                      router.push(
-                        `/runner/venue/${venue.venue_id}/stall/selectstall`
-                      )
-                    }
-                  >
-                    <img
-                      src={venue.image_url}
-                      alt={venue.name}
-                      className="w-16 h-16 rounded-md object-cover flex-shrink-0"
-                    />
-
-                    <div className="flex flex-col">
-                      <span className="font-semibold text-[15px] text-black leading-tight">
-                        {venue.name}
-                      </span>
-                      <span className="text-sm text-gray-500 leading-tight">
-                        {venue.address}
-                      </span>
-                    </div>
-                  </div>
-                </li>
-              ))
-            ) : (
-              <li>No venues found</li>
-            )}
-          </ul>
+          <DisplayGrid
+            items={venues.map((venue) => ({
+              id: venue.venue_id,
+              name: venue.name,
+              img: venue.image_url,
+            }))}
+            variant="venue"
+            href={(id: string) => `/runner/venue/${id}/stall/selectstall`}
+          />
         )}
       </div>
     </main>

--- a/frontend/components/ui/cardholder.tsx
+++ b/frontend/components/ui/cardholder.tsx
@@ -5,7 +5,7 @@ import { Pencil } from "lucide-react";
 type CardProps = {
   name: string;
   img?: string;
-  variant?: "venue" | "stall";
+  variant?: "default" | "venue" | "stall";
 
   // stall-only
   isActive?: boolean;
@@ -20,10 +20,11 @@ function CardHolder({
     isActive,
     onActiveChange, 
     onEdit}: CardProps) {
-    const showActions = variant === "stall";
+    const showActions = variant === "default";
+    
     return (
-        <div className="w-80 h-80 flex flex-col rounded-xl bg-white shadow-md shadow-black/25">
-            <div className="flex-1 bg-amber-300 rounded-t-xl">
+        <div className="h-50 flex flex-col rounded-xl bg-white shadow-md shadow-black/25">
+            <div className="h-63 rounded-t-xl bg-gray-100 overflow-hidden">
                 {img ? (
                     <img src={img} alt={name} className="h-full w-full object-cover" />
                 ) : (

--- a/frontend/components/ui/displaygrid.tsx
+++ b/frontend/components/ui/displaygrid.tsx
@@ -1,0 +1,42 @@
+import { CardHolder } from "./cardholder";
+import { useRouter } from "next/navigation";
+
+function DisplayGrid({
+  items,
+  variant,
+  href,
+}: {
+  items: {
+    id: string;
+    name: string;
+    img?: string;
+    isActive?: boolean; // only for stalls
+  }[];
+  variant: "venue" | "stall";
+  href?: (id: string) => string;
+}) {
+  const router = useRouter();
+
+  return (
+    <div className="flex justify-center text-left mt-6 grid grid-cols-2 gap-4 sm:gap-5 lg:grid-cols-5">
+      {items.map((item) => {
+        const clickable = !!href;
+        return (
+          <div 
+            key={item.id}
+            onClick={clickable ? () => router.push(href(item.id)) : undefined}
+            className={`text-left cursor-pointer`}>
+              <CardHolder
+                name={item.name}
+                img={item.img}
+                variant={variant}
+                isActive={item.isActive}
+              />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export { DisplayGrid };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1447,6 +1447,7 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }


### PR DESCRIPTION
# Use cardholder component for displaying venues and stalls

## Landscape mode (rows of 5)
### VenueSelect page
<img width="1914" height="812" alt="Screenshot 2026-01-01 170650" src="https://github.com/user-attachments/assets/211cc32b-a925-40f1-9872-78b1a16fee07" />

### StallSelect page
<img width="1918" height="823" alt="Screenshot 2026-01-01 170635" src="https://github.com/user-attachments/assets/81adcef5-d5cb-45af-a4de-45c0ff98f29d" />

## Portrait mode, phone view (rows of 2)
<img width="227" height="437" alt="Screenshot 2026-01-01 170729" src="https://github.com/user-attachments/assets/087ab34c-2eb0-4a85-bb41-9c9a0c672dde" />