### PR TITLE
Fix incorrect stalls display on venue

### DIFF
--- a/frontend/app/runner/venue/[venueId]/stall/selectstall/page.tsx
+++ b/frontend/app/runner/venue/[venueId]/stall/selectstall/page.tsx
@@ -18,33 +18,31 @@ function StallSelectionContent() {
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
   const router = useRouter();
   const searchParams = useSearchParams();
+  const params = useParams<{ venueId: string }>();
   const { venueId, setVenueId} = useCartStore();
 
-  const [stalls, setStalls] = useState<Stall[]>([]); 
-  const [loading, setLoading] = useState(true); 
+  const [stalls, setStalls] = useState<Stall[]>([]);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  
+
   const [searchTerm, setSearchTerm] = useState("");
   const [sortBy, setSortBy] = useState("");
 
-  // 1. Sync URL Params to Store
+  // 1. Sync URL path param to store and fetch stalls
   useEffect(() => {
-    const vParam = searchParams.get("venue");
-    const tParam = searchParams.get("table");
+    const id = params.venueId
+      ? Number(params.venueId)
+      : Number(searchParams.get("venue")) || null;
 
-    if (vParam) setVenueId(Number(vParam));
-  }, [searchParams, setVenueId]);
+    if (!id) return;
 
-  // 2. Fetch Stalls based on dynamic venueId
-  useEffect(() => {
+    setVenueId(id);
+
     async function fetchStalls() {
-      // If we don't have a venueId yet (from store or URL), don't fetch
-      if (!venueId) return;
-
       try {
         setLoading(true);
-        const data = await api.getStallsByVenue(venueId); 
-        setStalls(data || []); 
+        const data = await api.getStallsByVenue(id);
+        setStalls(data || []);
       } catch (err: any) {
         console.error(err);
         setError("Failed to load stalls");
@@ -53,7 +51,7 @@ function StallSelectionContent() {
       }
     }
     fetchStalls();
-  }, [venueId]);
+  }, [params.venueId, searchParams, setVenueId]);
 
   useEffect(() => {
     if (loading) return;


### PR DESCRIPTION
What was happening

- Runner selects Venue A → stalls load correctly, venueId is saved in cart store
- Runner goes back and selects Venue B → page ignores 5 in the URL, fetches using the stale Venue A ID from the store → wrong stalls displayed

Fix

- Called useParams() to read venueId directly from the URL path
- Consolidated the sync and fetch logic into a single effect that derives the ID from the URL path first, falling back to the ?venue= query param. This eliminates the race condition where the fetch fired before the store could be updated
